### PR TITLE
fix-IAQ code for FireBeetle ESP8266 only, as well as fixing possible negative numbers in IAQ's .ino time calculation method.

### DIFF
--- a/examples/IAQ_I2C/IAQ_I2C.ino
+++ b/examples/IAQ_I2C/IAQ_I2C.ino
@@ -103,8 +103,8 @@ void loop()
         else Serial.println(" very bad");
       } else {
         Serial.println("IAQ not ready, please wait about 5 minutes");
-        Serial.print("IAQ not ready, You will have to wait ");
-        Serial.print((int)(305000-millis())/1000);
+        Serial.print("IAQ not ready, You have been wait ");
+        Serial.print((int)(millis())/1000);
         Serial.println(" seconds");
       }
     }

--- a/examples/IAQ_SPI/IAQ_SPI.ino
+++ b/examples/IAQ_SPI/IAQ_SPI.ino
@@ -104,8 +104,8 @@ void loop()
         else Serial.println(" very bad");
       } else {
         Serial.println("IAQ not ready, please wait about 5 minutes");
-        Serial.print("IAQ not ready, You will have to wait ");
-        Serial.print((int)(305000-millis())/1000);
+        Serial.print("IAQ not ready, You have been wait ");
+        Serial.print((int)(millis())/1000);
         Serial.println(" seconds");
       }
     }

--- a/examples/IAQ_SPI/IAQ_SPI.ino
+++ b/examples/IAQ_SPI/IAQ_SPI.ino
@@ -1,7 +1,7 @@
 /*!
  * @file IAQ_SPI.ino
  * @brief Connect bme68x 4 wires SPI interface with your board (please reference board compatibility).
- * @n BME68x cs pin connect to D3 on esp8266 and esp32 board, on AVR board is IO 3.
+ * @n BME68x cs pin connect to D3 on FireBeetle esp8266 
  * @n Temprature, Humidity, pressure, altitude, calibrated altitude, gas resistance and IAQ data will be printed via serial.
  * @note This demo only support ESP8266 MCU
  *


### PR DESCRIPTION
The IAQ calculation process will print a negative number if it takes too long. Also, no ESP32 or AVR controller information should appear in the description of IAQ_SPI. As this code only applies to the FireBeetle ESP8266.

-----------------------------------------------------------------------------------------------------------------------------------------------

IAQ计算过程中，如果灯带时间过长会打印负数。同时，IAQ_SPI的描述中不应该出现ESP32或者AVR控制器的信息，该代码仅适用于FireBeetle ESP8266.

![099e22fc2f78d2eb127b30a80046af1](https://github.com/DFRobot/DFRobot_BME68x/assets/84136301/795b3091-3858-49d9-b37d-b557a29a6105)
